### PR TITLE
将channel数据类型变为有符号

### DIFF
--- a/core/Arduino.h
+++ b/core/Arduino.h
@@ -49,7 +49,7 @@ typedef struct
     uint8_t arduino_pin;
     rt_ubase_t rt_pin;
     const char* device_name;
-    rt_uint8_t channel;
+    rt_int8_t channel;
 }pin_map_t;
 
 typedef unsigned int word;


### PR DESCRIPTION
互补输出的时候，通道要设置为负数

比如 CH1  是  1
     CH1N 是 -1

所以修改一下数据类型