### PR TITLE
重新实现interrupts()/noInterrupts()

### DIFF
--- a/core/Arduino.h
+++ b/core/Arduino.h
@@ -103,21 +103,8 @@ typedef uint8_t byte;
 #define sq(x) ((x)*(x)) /* x^2 */
 
 /* define interrupts and noInterrupts */
-#if defined(__CM_CMSIS_VERSION) /* CMSIS for all ARM Cortex CPU */
-#define interrupts()   __enable_irq()
-#define noInterrupts() __disable_irq()
-#ifndef F_CPU
-extern uint32_t SystemCoreClock;
-#define F_CPU SystemCoreClock
-#ifndef RTDUINO_TINY_MODE
-#warning "This is just a backup solution. Please define F_CPU in pins_arduino.h"
-#endif /* RTDUINO_TINY_MODE */
-#endif /* F_CPU */
-#elif !defined(interrupts) || !defined(noInterrupts)
 #define interrupts()
 #define noInterrupts()
-#warning "Please define interrupts for this architecture in Arduino.h"
-#endif /* interrupts and noInterrupts */
 
 #ifdef F_CPU
 #define clockCyclesPerMicrosecond()  (F_CPU / 1000000L)


### PR DESCRIPTION
原来的方案中有以下问题：
1.各种CPU架构都需要在Arduino.h中实现一遍，这个工作本来是由RT-Thread底层完成的，RTduino不应该摸到底层 2.rt_hw_interrupt_disable/enable()已经实现相关功能，但是因为接口问题没有用上 3.无嵌套直接关闭/开启中断适合裸机，但是在RTOS加持下，这么做可能会出现问题