### PR TITLE
[add] 支持引脚动态转换功能

### DIFF
--- a/core/Arduino.h
+++ b/core/Arduino.h
@@ -179,6 +179,7 @@ void randomSeed(unsigned long);
 
 /* Don't invoke this function manually */
 void initVariant(void);
+char *pins_func_change(uint8_t pin, const char *func_name);
 
 #ifdef __cplusplus
 } /* extern "C" { */

--- a/core/RTduino.cpp
+++ b/core/RTduino.cpp
@@ -123,6 +123,8 @@ static void hwtimer_1us_init(void)
 
 /* initialization for BSP; maybe a blank function  */
 rt_weak void initVariant(void) {}
+/* Switch the function of the pin */
+rt_weak char *pins_func_change(uint8_t pin, const char *func_name) {}
 
 static int rtduino_init(void)
 {

--- a/core/wiring_analog.c
+++ b/core/wiring_analog.c
@@ -50,11 +50,23 @@ void analogWriteFrequency(uint32_t frequency)
 
 void analogWrite(uint8_t pin, int val)
 {
+    char *modify_name;
+
     RTDUINO_CHECK_PIN_LIMIT_RETURN(pin,); /* without return value */
 
 #ifdef RT_USING_PWM
     struct rt_device_pwm *pwm_dev;
     rt_uint32_t rt_pwm_val;
+
+    if (rt_memcmp(pin_map_table[pin].device_name, "pwm", 3))
+    {
+        modify_name = pins_func_change(pin, "pwm");
+        if (modify_name != RT_NULL)
+        {
+            /* Modify the device_name of pin_map_table */
+            pin_map_table[pin].device_name = modify_name;
+        }
+    }
 
     pwm_dev = (struct rt_device_pwm*)rt_device_find(pin_map_table[pin].device_name);
     if(pwm_dev != RT_NULL && pwm_dev->parent.type == RT_Device_Class_PWM)

--- a/core/wiring_private.h
+++ b/core/wiring_private.h
@@ -17,7 +17,7 @@
 #include <Arduino.h>
 
 #ifndef RTDUINO_TINY_MODE
-extern const pin_map_t pin_map_table[];
+extern pin_map_t pin_map_table[];
 
 /*
  * If pins_arduino.h defined RTDUINO_PIN_MAX_LIMIT which is the maximum of RTduino pin number,

--- a/libraries/buildin/SPI/SPI.cpp
+++ b/libraries/buildin/SPI/SPI.cpp
@@ -24,6 +24,7 @@
  */
 
 #include "SPI.h"
+#include "wiring_private.h"
 
 #define DBG_TAG    "RTduino.SPI"
 #define DBG_LVL    DBG_INFO
@@ -33,10 +34,29 @@ SPIClass SPI;
 
 void SPIClass::begin(const char *spi_bus_name)
 {
+    char *modify_name;
+
     if(rt_spi_bus_attach_device(&this->spi_device, "spiardu", spi_bus_name, NULL) != RT_EOK)
     {
         LOG_E("SPI device fail to attach!");
+        return;
     }
+
+#if defined(SCK) && defined(MISO) && defined(MOSI)
+    if (rt_memcmp(pin_map_table[SCK].device_name, "spi", 3) ||
+        rt_memcmp(pin_map_table[MISO].device_name, "spi", 3) ||
+        rt_memcmp(pin_map_table[MOSI].device_name, "spi", 3) )
+    {
+        modify_name = pins_func_change(PIN_NONE, "spi");
+        if (modify_name != RT_NULL)
+        {
+            /* Modify the device_name of pin_map_table */
+            pin_map_table[SCK].device_name = modify_name;
+            pin_map_table[MISO].device_name = modify_name;
+            pin_map_table[MOSI].device_name = modify_name;
+        }
+    }
+#endif /* defined(SCK) && defined(MISO) && defined(MOSI) */
 }
 
 void SPIClass::beginTransaction(SPISettings settings)


### PR DESCRIPTION
添加pins_func_change函数，可以实现动态转换引脚的功能。
目前只实现了PWM和SPI的动态转换，其他功能的引脚转换可以参考

```c
if (rt_memcmp(pin_map_table[SCK].device_name, "spi", 3) ||
    rt_memcmp(pin_map_table[MISO].device_name, "spi", 3) ||
    rt_memcmp(pin_map_table[MOSI].device_name, "spi", 3) )
{
    modify_name = pins_func_change(PIN_NONE, "spi");
    if (modify_name != RT_NULL)
    {
        /* Modify the device_name of pin_map_table */
        pin_map_table[SCK].device_name = modify_name;
        pin_map_table[MISO].device_name = modify_name;
        pin_map_table[MOSI].device_name = modify_name;
    }
}

if (rt_memcmp(pin_map_table[pin].device_name, "pwm", 3))
{
    modify_name = pins_func_change(pin, "pwm");
    if (modify_name != RT_NULL)
    {
        /* Modify the device_name of pin_map_table */
        pin_map_table[pin].device_name = modify_name;
    }
}

```

## 这里SPI实现的基本思路如下：

1.首先判断SPI使用的这几个引脚是否默认就为SPI功能(根据pin_map_table的device_name属性来判断)。
2.如果本身就是SPI功能，那么就没必要调用pins_func_change函数转换引脚功能。
3.如果不是SPI功能，那么就调用pins_func_change函数去转换引脚功能，并且此函数的返回值为SPI的具体外设。
4.重新赋值pin_map_table的device_name属性为新的功能，避免反复调用pins_func_change函数。

> PWM实现思路相同

## pins_func_change函数该做些什么事情：
1.关闭上一个外设的时钟，并且DeInit使用的引脚
2.开启现在外设的时钟，并且重新配置引脚
3.返回新外设的设备名

例如：
```c
__HAL_RCC_TIM1_CLK_DISABLE();
HAL_GPIO_DeInit(GPIOA, GPIO_PIN_7);

GPIO_InitTypeDef GPIO_InitStruct = {0};
__HAL_RCC_SPI1_CLK_ENABLE();
__HAL_RCC_GPIOA_CLK_ENABLE();
/**SPI1 GPIO Configuration
PA5     ------> SPI1_SCK
PA6     ------> SPI1_MISO
PA7     ------> SPI1_MOSI
*/
GPIO_InitStruct.Pin = GPIO_PIN_5 | GPIO_PIN_6 | GPIO_PIN_7;
GPIO_InitStruct.Mode = GPIO_MODE_AF_PP;
GPIO_InitStruct.Pull = GPIO_NOPULL;
GPIO_InitStruct.Speed = GPIO_SPEED_FREQ_VERY_HIGH;
GPIO_InitStruct.Alternate = GPIO_AF5_SPI1;
HAL_GPIO_Init(GPIOA, &GPIO_InitStruct);

return RTDUINO_DEFAULT_SPI_BUS_NAME;
```

## 注意
对于像SPI，I2C，UART这种  RTduino并不知道使用的什么引脚，当需要实现复用引脚的时候需要在对接的时候在pins_arduino.h文件里面添加引脚信息：

```c
#define SS          D7
#define SCK         D13  // 请添加
#define MISO        D12  // 请添加
#define MOSI        D11  // 请添加
#define RTDUINO_DEFAULT_SPI_BUS_NAME      "spi1"
```

