### PR TITLE
[Keil] Keil-MDK5 5.38 --cpp11报错

### DIFF
--- a/core/SConscript
+++ b/core/SConscript
@@ -38,7 +38,7 @@ elif rtconfig.PLATFORM in ['armcc']: # Keil AC5
     CXXFLAGS += ' --gnu --c99' # enable global C99 and GNU extension support for the whole project
     LOCAL_CCFLAGS += ' --gnu -g -W'
     LOCAL_CFLAGS += ' --c99' # cannot use --c99 symbol for C++ files, pertically in Keil
-    LOCAL_CXXFLAGS += ' --cpp11' # support C++11
+    # LOCAL_CXXFLAGS += ' --cpp11' # support C++11, Keil5 5.38 doesn't support C++11
 else:
     print('[RTduino] Unsupported rtconfig.PLATFORM: {}'.format(rtconfig.PLATFORM))
     Return('group')

--- a/core/WString.cpp
+++ b/core/WString.cpp
@@ -699,7 +699,7 @@ void String::remove(unsigned int index){
 }
 
 void String::remove(unsigned int index, unsigned int count) {
-    if (index >= len || buffer == nullptr) { return; }
+    if (index >= len || buffer == NULL) { return; }
     if (count == 0) { return; }
     if (count > len - index) { count = len - index; }
     len = len - count;


### PR DESCRIPTION
社区小伙伴报告问题：
在5.38 Keil MDK5上，使用 --cpp11 flag Keil5不认：
![26d1bbb2901d1bf49ff338566005216](https://github.com/RTduino/RTduino/assets/34888354/5b252068-f9e8-4824-828b-4c9e13771ba9)
![c36bdfcbf48137335bd895a9c9ed6ca](https://github.com/RTduino/RTduino/assets/34888354/20287929-b24f-4195-8f2e-3bd3a8f8d7d9)
![1f75dabd57d27866f12bef472714af5](https://github.com/RTduino/RTduino/assets/34888354/548dc2a1-b83f-43b0-aeda-beaa6d79b412)

但是Keil5 低版本可以验证过：
![image](https://github.com/RTduino/RTduino/assets/34888354/b36b6399-c51e-460d-9f44-823a805ac44d)
